### PR TITLE
Increase z-index for dialog to appear at the front

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -107,6 +107,7 @@ main section {
 	top:0;
 	left:0;
 	visibility: hidden;
+	z-index: 1;
 }
 dialog.open {
 	visibility: visible;


### PR DESCRIPTION
Issue - Due to same visibility, the action buttons were not clickable for dialog when opened over the code editor properties (like function).
Fix - Increase the visibility layer of dialog by increasing the z-index for dialog.