### PR TITLE
feat: Apply window properties immediately on save & improve editor height

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This Chrome extension allows users to add custom properties to the global window
 - Add custom properties of various types (string, number, boolean, array, object, function) to the window object
 - Intuitive UI for easy property management
 - Syntax highlighting helps identify and reduce errors in property values.
-- Updates to the window object upon saving changes and page reload
+- Instant updates to the window object upon saving changes (no page reload required)
 - Persistent storage of custom properties across page reloads
 - Error handling and logging for robustness
 
@@ -50,7 +50,7 @@ This Chrome extension allows users to add custom properties to the global window
 3. For each property type (except object), there is a default value provided for convenience, update the value as per your requirement.
 <img width="517" alt="Screenshot 2025-01-25 at 6 39 34 PM" src="https://github.com/user-attachments/assets/de2f1c95-0bfb-46a8-9e61-be2db914622d" />
 
-4. The properties added would be available on the window object after saving the changes and reloading the page.
+4. The properties added would be available on the window object immediately after saving the changes (no page reload required).
 <img width="316" alt="Screenshot 2025-01-25 at 6 42 42 PM" src="https://github.com/user-attachments/assets/7871ccde-73ae-49e8-bc59-a64938a91517" />
 
 ## Technical Details

--- a/scripts/aceEditorHelpers.js
+++ b/scripts/aceEditorHelpers.js
@@ -56,7 +56,7 @@ const memoizedEditorOptions = (() => {
 		enableBasicAutocompletion: true,
 		enableLiveAutocompletion: true,
 		enableSnippets: true,
-		maxLines: 4,
+		maxLines: 15,
 		minLines: 2,
 		highlightActiveLine: true,
 		highlightGutterLine: true,

--- a/scripts/updateLocalStorage.js
+++ b/scripts/updateLocalStorage.js
@@ -22,14 +22,26 @@ const indicateUserAboutSaveStatus = (isSuccess) => {
 export const updateLocalStorage = async (dataKey, data) => {
 	try {
 		const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-		const results = await executeScriptAsync({
+
+		// First, save to localStorage
+		const saveResults = await executeScriptAsync({
 			tabId: tab.id,
 			func: updateLocalStorageInTab,
 			args: [dataKey, data],
 		});
 
-		const isSuccess = results[0].result;
-		indicateUserAboutSaveStatus(isSuccess);
+		const isSaveSuccess = saveResults[0].result;
+
+		if (isSaveSuccess) {
+			// Re-run the existing content script to apply properties to window
+			await chrome.scripting.executeScript({
+				target: { tabId: tab.id },
+				files: ['scripts/contentScripts/attachDataToWindow.js'],
+				world: 'MAIN',
+			});
+		}
+
+		indicateUserAboutSaveStatus(isSaveSuccess);
 	} catch (error) {
 		console.error('Error executing script:', error);
 		indicateUserAboutSaveStatus(false);


### PR DESCRIPTION
## Description

### Summary
This PR improves the user experience by applying window properties immediately when the user clicks save, without requiring a page refresh. It also increases the editor's visible lines for better code visibility.

### Changes

#### 1. Instant Property Application on Save
Previously, properties defined via this extension were only applied to the browser window on page load. Users had to manually refresh the page after saving to see their changes take effect.

Now, when the user clicks the **Save** button:
1. Data is saved to localStorage (as before)
2. The content script (`attachDataToWindow.js`) is re-executed in the `MAIN` world to immediately apply the properties to the `window` object

This eliminates the need for a page refresh, providing instant feedback.

#### 2. Improved Ace Editor Height
Increased `maxLines` from `4` to `15` for the Ace Editor, allowing users to see more lines of code at once without scrolling within the editor.

### Files Changed
| File | Changes |
|------|---------|
| `scripts/updateLocalStorage.js` | Added logic to re-execute content script after successful save |
| `scripts/aceEditorHelpers.js` | Increased `maxLines` from 4 to 15 |

### Testing
- [ ] Verify properties are applied immediately after clicking Save (no refresh needed)
- [ ] Verify Ace Editor displays more lines by default
- [ ] Verify existing functionality still works (add/remove properties, different data types)